### PR TITLE
docs: add bare-bones docs/ folder for Jekyll documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ lib-cov
 coverage
 *.lcov
 
+# JetBrains IDE folder
+/.idea/
+
 # nyc test coverage
 .nyc_output
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Cumulus Dashboard Documentation
+
+These documents are meant to be built as one part of the larger body of
+[Cumulus documentation](https://docs.smarthealthit.org/cumulus).
+
+To test changes here locally, read more at the [Cumulus docs repo](https://github.com/smart-on-fhir/cumulus).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+---
+title: Dashboard
+# audience: non-programmers familiar with Cumulus, but not the Dashboard
+# type: explanation
+---
+
+# Cumulus Dashboard
+
+**Population-scale healthcare charts at your fingertips.**
+
+The Dashboard is a web app that reads patient count data from the
+[Cumulus Aggregator](https://docs.smarthealthit.org/cumulus/aggregator/)
+and lets you design charts and graphs to explore that data.


### PR DESCRIPTION
This isn't much yet, but it's enough to include this repo in my in-progress Cumulus-wide doc site code: https://github.com/smart-on-fhir/cumulus (once we're public)

These docs should be expanded for sure, though. Probably some use-manual stuff, or a walk through of features or something. But that can all happen later, and I probably am not the best suited for that.